### PR TITLE
Clip the output of run_bm3d_wrap before the type conversion.

### DIFF
--- a/pybm3d/bm3d.pyx
+++ b/pybm3d/bm3d.pyx
@@ -132,12 +132,12 @@ def bm3d(input_array, *args, clip=True, **kwargs):
     input_array = np.atleast_3d(input_array).astype(np.float32)
 
     out = run_bm3d_wrap(input_array, *args, **kwargs)
-    out = np.array(out, dtype=initial_dtype).reshape(initial_shape)
     if clip:
         if np.issubdtype(initial_dtype, np.integer):
             dtype_info = np.iinfo(initial_dtype)
         else:
             dtype_info = np.finfo(initial_dtype)
         out = np.clip(out, dtype_info.min, dtype_info.max)
+    out = np.array(out, dtype=initial_dtype).reshape(initial_shape)
 
     return out


### PR DESCRIPTION
The type conversion of the output of run_bm3d_wrap from np.float32 to the input dtype leads to numeric overflow in the output when the input dtype is uint8. It appears the author has anticipated this overflow, but the clipping happens after the conversion (i.e. when the overflow has already happened). 

I included two images of the denoised output for the following script before and after the patch to bm3d.pyx.
```python
import numpy as np
import skimage.data
from skimage.measure import compare_psnr
from skimage import io

import pybm3d


noise_std_dev = 20
img = skimage.data.astronaut()
noise = np.random.normal(scale=noise_std_dev,
                         size=img.shape).astype(np.int8)

assert img.dtype == np.uint8
noisy_img = (img.astype(np.int16) + noise).clip(0, 255).astype(np.uint8)


out = pybm3d.bm3d.bm3d(noisy_img, noise_std_dev)

noise_psnr = compare_psnr(img, noisy_img)
out_psnr = compare_psnr(img, out)

print("PSNR of noisy image: ", noise_psnr)
print("PSNR of reconstructed image: ", out_psnr)
io.imsave(fname='/tmp/astronaut_pybm3d_{}-denoised.png'.format(noise_std_dev), arr=out)
io.imsave(fname='/tmp/astronaut_pybm3d_{}.png'.format(noise_std_dev), arr=noisy_img)
```
Before patch:
![astronaut_pybm3d_20-denoised-beforepatch](https://user-images.githubusercontent.com/1157936/59846520-66a8e900-9360-11e9-94ef-d50a7c303574.png)
After patch:
![astronaut_pybm3d_20-denoised-afterpatch](https://user-images.githubusercontent.com/1157936/59846519-66a8e900-9360-11e9-882d-a676c9129a36.png)
